### PR TITLE
Reference to main.js file on package.json instead of main.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "obsidian-sample-plugin",
   "version": "0.9.7",
   "description": "This is a sample plugin for Obsidian (https://obsidian.md)",
-  "main": "main.js",
+  "main": "main.ts",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
     "build": "rollup --config rollup.config.js"


### PR DESCRIPTION
The entry point of the package.json file was set to `main.js`. The repo only has the `main.ts`, so I suppose that it's a mistake.