### PR TITLE
add type checking at build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
-		"build": "node esbuild.config.mjs production"
+		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production"
 	},
 	"keywords": [],
 	"author": "",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "isolatedModules": true,
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
Esbuild skips type checking for higher speed. It's ok to skip type checking in `npm run dev`. But it's strongly recommended to add type checking back in `npm run build`.

`isolatedModules` is also needed because of [this](https://esbuild.github.io/content-types/#isolated-modules).