### PR TITLE
remove `package-lock.json` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 
 # npm
 node_modules
-package-lock.json
 
 # Don't include the compiled main.js file in the repo.
 # They should be uploaded to GitHub releases instead.


### PR DESCRIPTION
The lock files (from npm or yarn) MUST be under versioning so it's just wrong to add them to `.gitignore`