### PR TITLE
Fix README headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Obsidian Sample Plugin
+# Obsidian Sample Plugin
 
 This is a sample plugin for Obsidian (https://obsidian.md).
 
@@ -15,7 +15,7 @@ This sample plugin demonstrates some of the basic functionality the plugin API c
 - Registers a global click event and output 'click' to the console.
 - Registers a global interval which logs 'setInterval' to the console.
 
-### First time developing plugins?
+## First time developing plugins?
 
 Quick starting guide for new plugin devs:
 
@@ -29,7 +29,7 @@ Quick starting guide for new plugin devs:
 - Enable plugin in settings window.
 - For updates to the Obsidian API run `npm update` in the command line under your repo folder.
 
-### Releasing new releases
+## Releasing new releases
 
 - Update your `manifest.json` with your new version number, such as `1.0.1`, and the minimum Obsidian version required for your latest release.
 - Update your `versions.json` file with `"new-plugin-version": "minimum-obsidian-version"` so older versions of Obsidian can download an older version of your plugin that's compatible.
@@ -40,24 +40,24 @@ Quick starting guide for new plugin devs:
 > You can simplify the version bump process by running `npm version patch`, `npm version minor` or `npm version major` after updating `minAppVersion` manually in `manifest.json`.
 > The command will bump version in `manifest.json` and `package.json`, and add the entry for the new version to `versions.json`
 
-### Adding your plugin to the community plugin list
+## Adding your plugin to the community plugin list
 
 - Check https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md
 - Publish an initial version.
 - Make sure you have a `README.md` file in the root of your repo.
 - Make a pull request at https://github.com/obsidianmd/obsidian-releases to add your plugin.
 
-### How to use
+## How to use
 
 - Clone this repo.
 - `npm i` or `yarn` to install dependencies
 - `npm run dev` to start compilation in watch mode.
 
-### Manually installing the plugin
+## Manually installing the plugin
 
 - Copy over `main.js`, `styles.css`, `manifest.json` to your vault `VaultFolder/.obsidian/plugins/your-plugin-id/`.
 
-### Improve code quality with eslint (optional)
+## Improve code quality with eslint (optional)
 - [ESLint](https://eslint.org/) is a tool that analyzes your code to quickly find problems. You can run ESLint against your plugin to find common bugs and ways to improve your code. 
 - To use eslint with this project, make sure to install eslint from terminal:
   - `npm install -g eslint`
@@ -68,6 +68,6 @@ Quick starting guide for new plugin devs:
   - `eslint .\src\`
 
 
-### API Documentation
+## API Documentation
 
 See https://github.com/obsidianmd/obsidian-api


### PR DESCRIPTION
The README erroneously used `<h2>` for top-level headings, `<h3>` for second-level headings, etc. This is bad for accessibility; see https://usability.yale.edu/web-accessibility/articles/headings#using.