### PR TITLE
enforce strictNullChecks in the beginning

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "target": "ES6",
     "allowJs": true,
+    "strictNullChecks": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
     "importHelpers": true,


### PR DESCRIPTION
Similar to noImplicitAny, strictNullChecks helps developers avoid unnecessary errors.
It might be better to enforce strictNullChecks in the beginning (as this is the sample project), since it's quite hard to fix the null/undefined problems after the project grows.