### PR TITLE
Add a warning about using >ES7 javascript features on ios mobile

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
       "DOM",
       "ES5",
       "ES6",
-      "ES7"
+      "ES7" //ES7 is the latest javascript version supported by the Obsidian IOS mobile app
     ]
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
       "DOM",
       "ES5",
       "ES6",
-      "ES7" //ES7 is the latest javascript version supported by the Obsidian IOS mobile app
+      "ES7" //ES7 is the latest javascript version supported by the Obsidian iOS mobile app
     ]
   },
   "include": [


### PR DESCRIPTION
Helps plugin developers avoid using javascript features that will break on the ios mobile app because of [Capacitor's support for up to ES2017](https://capacitorjs.com/docs/web#browser-support)

@Calorion noticed this issue in a few people's plugins, including mine (https://github.com/swar8080/obsidian-plugin-update-tracker/issues/5#issuecomment-1312498228)