### PR TITLE
Upgrade esbuild to v0.17.x

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import process from "process";
-import builtins from 'builtin-modules'
+import builtins from "builtin-modules";
 
 const banner =
 `/*
@@ -9,34 +9,34 @@ if you want to view the source, please visit the github repository of this plugi
 */
 `;
 
-const prod = (process.argv[2] === 'production');
+const prod = (process.argv[2] === "production");
 
 esbuild.build({
 	banner: {
 		js: banner,
 	},
-	entryPoints: ['main.ts'],
+	entryPoints: ["main.ts"],
 	bundle: true,
 	external: [
-		'obsidian',
-		'electron',
-		'@codemirror/autocomplete',
-		'@codemirror/collab',
-		'@codemirror/commands',
-		'@codemirror/language',
-		'@codemirror/lint',
-		'@codemirror/search',
-		'@codemirror/state',
-		'@codemirror/view',
-		'@lezer/common',
-		'@lezer/highlight',
-		'@lezer/lr',
+		"obsidian",
+		"electron",
+		"@codemirror/autocomplete",
+		"@codemirror/collab",
+		"@codemirror/commands",
+		"@codemirror/language",
+		"@codemirror/lint",
+		"@codemirror/search",
+		"@codemirror/state",
+		"@codemirror/view",
+		"@lezer/common",
+		"@lezer/highlight",
+		"@lezer/lr",
 		...builtins],
-	format: 'cjs',
+	format: "cjs",
 	watch: !prod,
-	target: 'es2018',
+	target: "es2018",
 	logLevel: "info",
-	sourcemap: prod ? false : 'inline',
+	sourcemap: prod ? false : "inline",
 	treeShaking: true,
-	outfile: 'main.js',
+	outfile: "main.js",
 }).catch(() => process.exit(1));

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -11,7 +11,7 @@ if you want to view the source, please visit the github repository of this plugi
 
 const prod = (process.argv[2] === "production");
 
-esbuild.build({
+const context = await esbuild.context({
 	banner: {
 		js: banner,
 	},
@@ -33,10 +33,16 @@ esbuild.build({
 		"@lezer/lr",
 		...builtins],
 	format: "cjs",
-	watch: !prod,
 	target: "es2018",
 	logLevel: "info",
 	sourcemap: prod ? false : "inline",
 	treeShaking: true,
 	outfile: "main.js",
-}).catch(() => process.exit(1));
+});
+
+if (prod) {
+	await context.rebuild();
+	process.exit(0);
+} else {
+	await context.watch();
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
-		"esbuild": "0.14.47",
+		"esbuild": "0.17.3",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"


### PR DESCRIPTION
The `v0.17.x` versions of `esbuild` contain breaking changes that require modifications to your configuration file, `esbuild.config.mjs`.

Without these changes, running `npm run build` or `npm run dev` produces an output like this:

```
✘ [ERROR] Invalid option in build() call: "watch"
```

This updates the config file to match the new requirements, preserving all existing functionality, including our "build" and "dev" modes in `package.json`'s `scripts`.

Fixes https://github.com/obsidianmd/obsidian-sample-plugin/issues/45.