### PR TITLE
Update the list of features of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ The repo depends on the latest plugin API (obsidian.d.ts) in Typescript Definiti
 **Note:** The Obsidian API is still in early alpha and is subject to change at any time!
 
 This sample plugin demonstrates some of the basic functionality the plugin API can do.
-- Changes the default font color to red using `styles.css`.
 - Adds a ribbon icon, which shows a Notice when clicked.
 - Adds a command "Open Sample Modal" which opens a Modal.
 - Adds a plugin setting tab to the settings page.


### PR DESCRIPTION
In https://github.com/obsidianmd/obsidian-sample-plugin/commit/64e86498772c97c6f49fd28698405547fd44dc60, the setting of the colour was removed from `styles.css`. However, the info in the `README.md` file was still mentioning it.

In this changeset, we update `README.md` to reflect the current list of features the plugin has.