### PR TITLE
Automate release process with a GitHub action

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,70 @@
+# Creates a new GitHub Release when a tag is pushed
+# See https://docs.obsidian.md/Plugins/Releasing/Submit+your+plugin#Step+2+Create+a+release
+# Tag should be in the format of x.y.z without `v` prefix
+# For example `1.0.0` is a valid tag, but `v1.0.0` is not
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  # IMPORTANT: Update this with the name of your plugin
+  PLUGIN_NAME: my-plugin
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Build and zip
+        id: build
+        run: |
+          tag=${GITHUB_REF#refs/*/}
+          # Set tag as output for following steps
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+
+          # Update version in manifest.json and package.json
+          jq --arg tag "$tag" '.version = $tag' manifest.json >> tmp.$$.json && mv tmp.$$.json manifest.json
+          jq --arg tag "$tag" '.version = $tag' package.json >> tmp.$$.json && mv tmp.$$.json package.json
+
+          # Build and zip release
+          npm install
+          npm run build
+          mkdir ${{ env.PLUGIN_NAME }}
+          cp styles.css main.js manifest.json ${{ env.PLUGIN_NAME }}
+          zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
+
+      - name: Commit version changes
+        uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081
+        with:
+          default_author: github_actor
+          add: 'manifest.json package.json package-lock.json'
+          message: 'Release v${{ steps.build.outputs.tag }}'
+          push: 'origin HEAD:${{ github.event.repository.default_branch }} --force'
+          # Override existing tag with new tag that has version bump
+          tag: '${{ steps.build.outputs.tag }} --force'
+          tag_push: '--force'
+
+      - name: Release with files
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        with:
+          name: ${{ steps.build.outputs.tag }}
+          body: "*Release of ${{ env.PLUGIN_NAME }} v${{ steps.build.outputs.tag }} auto-created by [release.yml](.github/workflows/release.yml)*"
+          files: |
+            ${{ env.PLUGIN_NAME }}.zip
+            main.js
+            manifest.json
+            styles.css

--- a/README.md
+++ b/README.md
@@ -43,14 +43,20 @@ Quick starting guide for new plugin devs:
 
 ### Automatically
 
-Using the [release](.github/release.yml) workflow, you can create and push a tag. For example,
+In [.github/release.yml](.github/release.yml) replace "my-plugin" with the name of your plugin on the following line,
 
+```yml
+  PLUGIN_NAME: my-plugin
 ```
+
+After updating your plugin name, you can create and push a tag. For example,
+
+```bash
 git tag 1.2.3
 git push origin 1.2.3
 ```
 
-The workflow will automatically:
+Then [release.yml](.github/release.yml) will automatically:
 1. Update `manifest.json`, `package.json`, and `package-lock.json` with the version from your tag.
 2. Commit the updates to your repo (that you will need to pull down locally before making further changes)
 3. Create a new release for your tag in your [repo's Releases](https://github.com/obsidianmd/obsidian-sample-plugin/releases).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Quick starting guide for new plugin devs:
 
 ## Releasing new releases
 
+### Manually
+
 - Update your `manifest.json` with your new version number, such as `1.0.1`, and the minimum Obsidian version required for your latest release.
 - Update your `versions.json` file with `"new-plugin-version": "minimum-obsidian-version"` so older versions of Obsidian can download an older version of your plugin that's compatible.
 - Create new GitHub release using your new version number as the "Tag version". Use the exact version number, don't include a prefix `v`. See here for an example: https://github.com/obsidianmd/obsidian-sample-plugin/releases
@@ -38,6 +40,24 @@ Quick starting guide for new plugin devs:
 
 > You can simplify the version bump process by running `npm version patch`, `npm version minor` or `npm version major` after updating `minAppVersion` manually in `manifest.json`.
 > The command will bump version in `manifest.json` and `package.json`, and add the entry for the new version to `versions.json`
+
+### Automatically
+
+Using the [release](.github/release.yml) workflow, you can create and push a tag. For example,
+
+```
+git tag 1.2.3
+git push origin 1.2.3
+```
+
+The workflow will automatically:
+1. Update `manifest.json`, `package.json`, and `package-lock.json` with the version from your tag.
+2. Commit the updates to your repo (that you will need to pull down locally before making further changes)
+3. Create a new release for your tag in your [repo's Releases](https://github.com/obsidianmd/obsidian-sample-plugin/releases).
+
+Afterwards, you should manually update the Release's notes detailing your changes, and update your `versions.json` file with the minimum version of Obsidian your plugin supports.
+
+**Note:** Tag names must be in the format `x.y.z` without prefixing a `v`, for instance `1.0.0` is valid, but `v1.0.0` is not.
 
 ## Adding your plugin to the community plugin list
 


### PR DESCRIPTION
Adds the option for people who use this template to push version tags to automate (nearly) every part of a standard Obsidian release.

When pushing a valid tag, e.g. `1.2.3` this action:
1. Updates `manifest.json`, `package.json`, and `package-lock.json` with the version from the tag.
2. Commit the updates to your repo (that will need to be pulled down locally before making further changes).
3. Creates a new GitHub release for the tag.
