### PR TITLE
Update manifest description

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Sample Plugin",
 	"version": "1.0.0",
 	"minAppVersion": "0.15.0",
-	"description": "This is a sample plugin for Obsidian. This plugin demonstrates some of the capabilities of the Obsidian API.",
+	"description": "Demonstrates some of the capabilities of the Obsidian API.",
 	"author": "Obsidian",
 	"authorUrl": "https://obsidian.md",
 	"fundingUrl": "https://obsidian.md/pricing",


### PR DESCRIPTION
The [Submission requirements for plugins](https://docs.obsidian.md/Plugins/Releasing/Submission+requirements+for+plugins) states:

> Avoid starting your description with "This is a plugin", because it'll be obvious to users in the context of the Community Plugins directory.

Removing "this is a plugin" from the description of the sample plugin will help people to avoid this mistake.