### PR TITLE
Minify production build

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -38,6 +38,7 @@ const context = await esbuild.context({
 	sourcemap: prod ? false : "inline",
 	treeShaking: true,
 	outfile: "main.js",
+	minify: prod,
 });
 
 if (prod) {


### PR DESCRIPTION
Enable minification in production mode for a smaller deployment bundle. Skips minification in development.

People using this sample repo might not go into the trouble of including a minification step themselves.

Closes #70