### PR TITLE
FEAT: Automate Bump Version, Create Release and Generate Artifacts using GitHub Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,116 @@
+name: Create Release
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm install
+
+      - name: Build the plugin
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm run build
+
+      - name: Extract version from manifest.json
+        id: get_version
+        run: |
+          version=$(jq -r '.version' manifest.json)
+          echo "Version found: $version"
+          echo "manifest_version=$version" >> $GITHUB_ENV
+
+      - name: Check if version exists
+        id: check_version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log("Checking version: " + process.env.manifest_version);
+            try {
+              const { data: releases } = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: process.env.manifest_version
+              });
+              const exists = releases.tag_name === process.env.manifest_version;
+              console.log(`Version exists: ${exists}`);
+              core.setOutput("version_exists", exists);
+            } catch (error) {
+              if (error.status === 404) {
+                console.log('Release does not exist.');
+                core.setOutput("version_exists", false);
+              } else {
+                throw error;
+              }
+            }
+
+      - name: Bump version if exists
+        if: ${{ steps.check_version.outputs.version_exists == 'true' }}
+        run: |
+          version=$(jq -r '.version' manifest.json)
+          IFS='.' read -ra parts <<< "$version"
+          parts[-1]=$((parts[-1] + 1))
+          new_version="${parts[*]}"
+          new_version=${new_version// /.}
+          echo "New version in manifest.json: $new_version"
+          jq ".version = \"$new_version\"" manifest.json > tmp_manifest.json
+          mv tmp_manifest.json manifest.json
+          echo "New version in package.json: $new_version"
+          jq ".version = \"$new_version\"" package.json > tmp_package.json
+          mv tmp_package.json package.json
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add manifest.json package.json
+          git commit -m "Bump version to $new_version"
+          git push
+          echo "manifest_version=$new_version" >> $GITHUB_ENV
+
+          echo -e "\e[32mVersion bumped to $new_version\e[0m"
+          echo -e "\e[32mRelease will be created in new workflow\e[0m"
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.manifest_version }}
+          release_name: Release ${{ env.manifest_version }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./main.js
+          asset_name: main.js
+          asset_content_type: application/javascript
+
+      - name: Upload manifest.json
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./manifest.json
+          asset_name: manifest.json
+          asset_content_type: application/json


### PR DESCRIPTION
# Overview
- Sample Plugin is like a boilerplate for building community plugin.
- This MR will ease the process after the maintainer finish the code changes
by doing following things in CI/CD using GitHub Actions

# Features
After maintainer make a new commit to their project's main branch (`main` or `master`)
1. GitHub Action will create new commit and increment version property in `package.json` and `manifest.json` files
![image](https://github.com/user-attachments/assets/05de71ae-34e1-41a5-9910-4cf70db119d6)
2. It also Create a Release and automatically attached build artifacts.
![image](https://github.com/user-attachments/assets/418a0ca6-3435-4edf-b69f-157b2fb7f56b)

Basically, developers or maintainers will only have to care about the code part, and let CI/CD (GitHub Action) handle the rest 🎉 

# Demo
- You can see them in action on my test repository here
- https://github.com/chaintng/test-auto-build-obs-plugin


# CAUTIONS
Your next git push might get **REJECTED** because the local 
`master` branch isn’t up-to-date with the remote one.

**How to Fix It ?**
1.	Update your branch with the latest changes by running
- `git pull --rebase`
2.	🎉 That’s it! Now try pushing again. You shouldn’t see the error anymore.
- `git push`

![image](https://github.com/user-attachments/assets/e1e0fdb8-3912-4966-9478-2778aaf4d151)


