### PR TITLE
Update Typescript Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
 		"esbuild": "0.17.3",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"typescript": "5.7.2"
 	}
 }


### PR DESCRIPTION
Svelte requires a 5.0.0+ version of typescript, so updating to the most recent version.