### PR TITLE
align sample manifest.json with modern Obsidian developer policies

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-	"id": "sample-plugin",
-	"name": "Sample Plugin",
+	"id": "sample",
+	"name": "Sample",
 	"version": "1.0.0",
 	"minAppVersion": "0.15.0",
 	"description": "Demonstrates some of the capabilities of the Obsidian API.",


### PR DESCRIPTION
- plugin's id should not contain `plugin`
- plugin's name should not contain the word "Plugin"