### PR TITLE
build: only write new minAppVersion requirements to `versions.json`

### DIFF
--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -3,12 +3,15 @@ import { readFileSync, writeFileSync } from "fs";
 const targetVersion = process.env.npm_package_version;
 
 // read minAppVersion from manifest.json and bump version to target version
-let manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
+const manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
 const { minAppVersion } = manifest;
 manifest.version = targetVersion;
 writeFileSync("manifest.json", JSON.stringify(manifest, null, "\t"));
 
 // update versions.json with target version and minAppVersion from manifest.json
-let versions = JSON.parse(readFileSync("versions.json", "utf8"));
-versions[targetVersion] = minAppVersion;
-writeFileSync("versions.json", JSON.stringify(versions, null, "\t"));
+// but only if the target version is not already in versions.json
+const versions = JSON.parse(readFileSync('versions.json', 'utf8'));
+if (!Object.values(versions).includes(minAppVersion)) {
+    versions[targetVersion] = minAppVersion;
+    writeFileSync('versions.json', JSON.stringify(versions, null, '\t'));
+}


### PR DESCRIPTION
Currently, the `version-bump.mjs` script will write a new `version`: `minAppVersion` pair on every run with a version which is not yet in `versions.json`. However, [we only need to update `versions.json` if the minAppVersion for the plugin changes](https://docs.obsidian.md/Reference/Versions). This PR modifies the script such that it only adds a new version requirement if `minAppVersion` in the current `manifest.json` is not already in `versions.json`. This should declutter `versions.json`.

**Important**:
This simply checks whether the `minAppVersion` is part of the `versions.json` or not. But it does not do any semantic comparisons of the existing versions against the new `minAppVersion`. This might lead to the (I guess unlikely, but entirely possible) situation that a lower `minAppVersion` for a newer plugin version is added to `versions.json`. I can't foresee if Obsidian would handle this gracefully, if that would be expected behaviour anyway, or if it would break things. However, since the current version of `version-bump.mjs` simply adds whatever `minAppVersion` the updated `manifest.json` contains, we won't be changing that fundamental behaviour. 