### PR TITLE
fix: version-bump.mjs

### DIFF
--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -2,6 +2,11 @@ import { readFileSync, writeFileSync } from "fs";
 
 const targetVersion = process.env.npm_package_version;
 
+if (!targetVersion) {
+	console.error("Error: npm_package_version is not set. This script must be run via 'npm version'.");
+	process.exit(1);
+}
+
 // read minAppVersion from manifest.json and bump version to target version
 const manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
 const { minAppVersion } = manifest;
@@ -11,7 +16,7 @@ writeFileSync("manifest.json", JSON.stringify(manifest, null, "\t"));
 // update versions.json with target version and minAppVersion from manifest.json
 // but only if the target version is not already in versions.json
 const versions = JSON.parse(readFileSync('versions.json', 'utf8'));
-if (!Object.values(versions).includes(minAppVersion)) {
+if (!versions[targetVersion]) {
     versions[targetVersion] = minAppVersion;
     writeFileSync('versions.json', JSON.stringify(versions, null, '\t'));
 }


### PR DESCRIPTION
This fixes two issue:
- If not run as part of the `npm version` process, the `process.env.npm_package_version` is not set and then the `version` property from `manifest.json` will get removed. The script should fail with an error if `targetVersion` cannot be determined.
- The `versions.json` file does not seem to get updated, the new version does not get added to the property list/dictionary.

Generated message below:

---

## Changes made:

1. **Added validation for `targetVersion`**: The script now checks if `process.env.npm_package_version` is set. If not, it prints an error message and exits with status code 1. This prevents the script from removing the version property from manifest.json when run outside the `npm version` context.

2. **Fixed the versions.json update logic**: Changed from `if (!Object.values(versions).includes(minAppVersion))` to `if (!versions[targetVersion])`. The original logic was checking if the minAppVersion VALUE existed anywhere in the versions dictionary, which was incorrect. The fix now properly checks if the targetVersion KEY already exists in the versions object, ensuring new versions are added correctly.

Both fixes are minimal and maintain the script's simplicity. The script will now:
- Fail safely if not run via `npm version`
- Correctly add new version entries to versions.json each time a new version is bumped