### PR TITLE
feat: add Bun runtime support as npm alternative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # npm
 node_modules
 
+# bun
+bun.lockb
+
 # Don't include the compiled main.js file in the repo.
 # They should be uploaded to GitHub releases instead.
 main.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,34 +8,52 @@
 
 ## Environment & tooling
 
-- Node.js: use current LTS (Node 18+ recommended).
-- **Package manager: npm** (required for this sample - `package.json` defines npm scripts and dependencies).
+- Node.js: use current LTS (Node 18+ recommended), or **Bun** (1.0+ recommended) as an alternative runtime.
+- **Package manager: npm or bun** (`package.json` defines scripts and dependencies compatible with both).
 - **Bundler: esbuild** (required for this sample - `esbuild.config.mjs` and build scripts depend on it). Alternative bundlers like Rollup or webpack are acceptable for other projects if they bundle all external dependencies into `main.js`.
 - Types: `obsidian` type definitions.
 
-**Note**: This sample project has specific technical dependencies on npm and esbuild. If you're creating a plugin from scratch, you can choose different tools, but you'll need to replace the build configuration accordingly.
+**Note**: This sample project supports both npm/Node.js and Bun. Choose the runtime that best fits your workflow.
 
 ### Install
 
+**Using npm:**
 ```bash
 npm install
 ```
 
+**Using Bun:**
+```bash
+bun install
+```
+
 ### Dev (watch)
 
+**Using npm:**
 ```bash
 npm run dev
 ```
 
+**Using Bun:**
+```bash
+bun run bun:dev
+```
+
 ### Production build
 
+**Using npm:**
 ```bash
 npm run build
 ```
 
+**Using Bun:**
+```bash
+bun run bun:build
+```
+
 ## Linting
 
-- To use eslint install eslint from terminal: `npm install -g eslint`
+- To use eslint install eslint from terminal: `npm install -g eslint` (or `bun add -g eslint`)
 - To use eslint to analyze this project use this command: `eslint main.ts`
 - eslint will then create a report with suggestions for code improvement by file and line number.
 - If your source code is in a folder, such as `src`, you can use eslint with this command to analyze all files in that folder: `eslint ./src/`
@@ -237,7 +255,7 @@ this.registerInterval(window.setInterval(() => { /* ... */ }, 1000));
 ## Troubleshooting
 
 - Plugin doesn't load after build: ensure `main.js` and `manifest.json` are at the top level of the plugin folder under `<Vault>/.obsidian/plugins/<plugin-id>/`. 
-- Build issues: if `main.js` is missing, run `npm run build` or `npm run dev` to compile your TypeScript source code.
+- Build issues: if `main.js` is missing, run `npm run build` (or `bun run bun:build`) or `npm run dev` (or `bun run bun:dev`) to compile your TypeScript source code.
 - Commands not appearing: verify `addCommand` runs after `onload` and IDs are unique.
 - Settings not persisting: ensure `loadData`/`saveData` are awaited and you re-render the UI after changes.
 - Mobile-only issues: confirm you're not using desktop-only APIs; check `isDesktopOnly` and adjust.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Quick starting guide for new plugin devs:
 - Check if [someone already developed a plugin for what you want](https://obsidian.md/plugins)! There might be an existing plugin similar enough that you can partner up with.
 - Make a copy of this repo as a template with the "Use this template" button (login to GitHub if you don't see it).
 - Clone your repo to a local development folder. For convenience, you can place this folder in your `.obsidian/plugins/your-plugin-name` folder.
-- Install NodeJS, then run `npm i` in the command line under your repo folder.
-- Run `npm run dev` to compile your plugin from `main.ts` to `main.js`.
+- Install NodeJS (or [Bun](https://bun.sh) as an alternative), then run `npm i` (or `bun install`) in the command line under your repo folder.
+- Run `npm run dev` (or `bun run bun:dev`) to compile your plugin from `main.ts` to `main.js`.
 - Make changes to `main.ts` (or create new `.ts` files). Those changes should be automatically compiled into `main.js`.
 - Reload Obsidian to load the new version of your plugin.
 - Enable plugin in settings window.
@@ -47,9 +47,9 @@ Quick starting guide for new plugin devs:
 ## How to use
 
 - Clone this repo.
-- Make sure your NodeJS is at least v16 (`node --version`).
-- `npm i` or `yarn` to install dependencies.
-- `npm run dev` to start compilation in watch mode.
+- Make sure your NodeJS is at least v16 (`node --version`), or use [Bun](https://bun.sh) 1.0+ as an alternative.
+- `npm i` or `yarn` or `bun install` to install dependencies.
+- `npm run dev` (or `bun run bun:dev`) to start compilation in watch mode.
 
 ## Manually installing the plugin
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
-		"lint": "eslint ."
+		"lint": "eslint .",
+		"bun:dev": "bun esbuild.config.mjs",
+		"bun:build": "bun run tsc -noEmit -skipLibCheck && bun esbuild.config.mjs production"
 	},
 	"keywords": [],
 	"license": "0-BSD",


### PR DESCRIPTION
## This is me, human! 😃 (I picked that emoji)

I'm just trying to build an extension using Bun instead of Node to maybe update to TypeScript. Maybe there are some major blockers, but let's see.

---

## This is copilot-generated

This pull request updates the documentation and tooling to add support for Bun as an alternative runtime and package manager alongside Node.js and npm. It introduces Bun-compatible install and build scripts, updates the quick start and troubleshooting guides, and adds Bun-specific commands to `package.json`. These changes make it easier for developers to use either Node.js/npm or Bun for plugin development.

**Tooling and build process updates:**
* Added Bun support to `package.json` with new scripts: `bun:dev` and `bun:build`, enabling Bun-based development and production builds.

**Documentation improvements:**
* Updated `AGENTS.md` to mention Bun as an alternative runtime, describe Bun-compatible install/build commands, and clarify linting instructions for Bun users.
* Enhanced troubleshooting instructions in `AGENTS.md` to include Bun-based build commands for resolving missing `main.js` issues.
* Revised the quick start guide in `README.md` to reference Bun as an alternative to Node.js, and updated install/build commands to include Bun equivalents.
* Updated usage instructions in `README.md` to show Bun as an option for installing dependencies and running the dev build.